### PR TITLE
feature/CCT-257

### DIFF
--- a/mrblib/system.rb
+++ b/mrblib/system.rb
@@ -1,112 +1,158 @@
+#
+# @file system.rb
+# @brief mruby-pax system utilities.
+# @platform Pax Prolin
+#
+# @copyright Copyright (c) 2016 CloudWalk, Inc.
+#
+
+# mruby-pax C/C++ interface exposure.
 class PAX
+  # Subclass definition.
   class System
-    DEFAULT_BACKLIGHT = 1
-    RET_OK            = 0
+    # (osal.h) enum POWER_TYPE macros
+    POWER_ADAPTER         = 1
+    POWER_USB             = 2
+    POWER_BATTERY         = 3
+    POWER_WPC             = 4
+
+    # (osal.h) System Manager macros
+    FILE_TYPE_APP         = 1
+    FILE_TYPE_APP_PARAM   = 2
+    FILE_TYPE_SYS_LIB     = 3
+    FILE_TYPE_PUB_KEY     = 4
+    FILE_TYPE_AUP         = 5
+    FILE_TYPE_KERNEL      = 6
+    FILE_TYPE_RAMDISK     = 7
+    FILE_TYPE_BASE        = 8
+    FILE_TYPE_FWP         = 9
+
+    # Deprecated macros
+    DEFAULT_BACKLIGHT     = 1
+
+    # Static class variables
+    @@battery_capacity = -1
+    @@semaphore = Mutex.new
+    @@timestamp = [Time.now, 0]
+
+    # Returns the device serial number.
+    def self.serial
+      _serial
+    end
+
+    # Defines screen brightness level [0~100].
+    def self.backlight=(level)
+      level.negative? && level = 0
+
+      level > 100 && level = 100
+
+      ret = _backlight = (level * 7 / 100).to_i
+
+      if level.zero?
+        _kb_backlight = 0
+        _sleep_mode = 1
+      else
+        _kb_backlight = 1
+        _sleep_mode = 0
+      end
+
+      ret
+    end
+
+    # (deprecated) Returns default backlight for DaFunk:
+    def self.backlight
+      # - 0: Turn off
+      # - 1: (D200) Keep on for 30 seconds
+      # - 2: (D200) Always on
+
+      DEFAULT_BACKLIGHT
+    end
+
+    # Defines system execution mode: 0 (active), 1 (screensaver) and 2
+    # (sleep).
+    def self.sleep_mode=(mode)
+      _sleep_mode = mode
+    end
+
+    # Defines keyboard backlight behavior: 0 to disable, non-zero to enable.
+    def self.kb_backlight=(level)
+      _kb_backlight = level
+    end
+
+    # Returns current battery capacity (%) in the range [-1~100].
+    def self.battery
+      @@semaphore.lock
+
+      @@timestamp[1] = Time.now
+
+      if @@timestamp[1] > @@timestamp[0]
+        @@timestamp[0] = Time.now + 4 # To prevent stressing both file system
+                                      # and battery
+
+        @@battery_capacity = _battery
+
+        ContextLog.info "System Battery - #{__method__}"
+      end
+
+      ContextLog.info "System Battery - Capacity [#{@@battery_capacity}%]"
+
+      capacity = @@battery_capacity
+
+      @@semaphore.unlock
+
+      capacity
+    end
+
+    # Checks if device is connected to any power supply.
+    def self.power_supply
+      [POWER_SOURCE_ADAPTER, POWER_SOURCE_USB].include?(_power_supply)
+    end
+
+    # Returns the device model (downcased).
+    def self.model
+      _model.to_s.downcase
+    end
+
+    # Reboots the device.
+    def self.reboot
+      _reboot
+    end
+
+    # Returns device brand (downcased).
+    def self.brand
+      'pax'
+    end
+
+    # Updates the main application.
+    def self.update(path)
+      ret = install('MAINAPP', path, FILE_TYPE_APP)
+      if !ret
+        true
+      else
+        ContextLog.info "System Update - Error [#{path}][#{ret.inspect}]"
+        false
+      end
+    end
+
+    # Returns versions from EMV, OS, PINPAD (built-in PED) and SDK.
+    def self.versions
+      unless @versions
+        @versions = {}
+
+        @versions['EMV'] = PAX::EMV.version
+        @versions['OS'] = _os_version
+        @versions['Pinpad'] = _pinpad_version
+        @versions['SDK'] = _osal_version
+      end
+      @versions
+    end
 
     def self.teardown
       PAX::Printer.thread_kill
     end
 
-    def self.serial
-      PAX::System._serial
-    end
-
-    def self.model
-      PAX::System._model.to_s.downcase
-    end
-
-    def self.kb_backlight=(level)
-      PAX::System._kb_backlight = level
-    end
-
-    def self.backlight=(level)
-      if level == 0
-        PAX::System._kb_backlight = level
-        PAX::System._sleep_mode   = 1
-        PAX::System._backlight    = level
-      else
-        PAX::System._backlight    = 7
-        PAX::System._kb_backlight = 1
-        PAX::System._sleep_mode   = 0
-      end
-    end
-
-    def self.backlight
-      DEFAULT_BACKLIGHT
-    end
-
-    def self.reboot
-      PAX::System._reboot
-    end
-
-    POWER_ADAPTER = 1
-    POWER_USB     = 2
-    POWER_BATTERY = 3
-
-    def self.power_supply
-      power = self._power_supply
-      power == POWER_ADAPTER || power == POWER_USB
-    end
-
-    BATTERY_LEVEL_0        = 0	# Power  0~20%
-    BATTERY_LEVEL_1        = 1	# Power 20~40%
-    BATTERY_LEVEL_2        = 2	# Power 40~60%
-    BATTERY_LEVEL_3        = 3	# Power 60~80%
-    BATTERY_LEVEL_4        = 4	# Power 80~100%
-    BATTERY_LEVEL_CHARGE   = 5	# Battery is being charged
-    BATTERY_LEVEL_COMPLETE = 6	# Battery charge complete
-    BATTERY_LEVEL_ABSENT   = 7	# Battery is absent
-
-    def self.battery
-      case value = self._battery
-      when 0..4
-        value * 25
-      when 5
-        50
-      when 6
-        100
-      else
-        -1
-      end
-    end
-
-    def self.brand
-      "pax"
-    end
-
-    FILE_TYPE_APP       = 1 # Application
-    FILE_TYPE_APP_PARAM = 2 # Application parameter
-    FILE_TYPE_SYS_LIB   = 3 # Dynamic system library
-    FILE_TYPE_PUB_KEY   = 4 # User public key
-    FILE_TYPE_AUP       = 5 # Application upgrade kit
-    FILE_TYPE_KERNEL    = 6	# Firmware kernel, "firmware-kernel"
-    FILE_TYPE_RAMDISK   =	7	# Firmware ramdisk, "firmware-ramdisk"
-    FILE_TYPE_BASE      = 8	# Firmware base, "firmware-base"
-
-    def self.update(path)
-      ret_install = self.install("MAINAPP", path, FILE_TYPE_APP)
-      if ret_install == RET_OK
-        true
-      else
-        ContextLog.info "System Update - Error [#{path}][#{ret_install.inspect}]"
-        false
-      end
-    end
-
-    def self.versions
-      unless @versions
-        @versions = Hash.new
-        @versions["OS"]     = self._os_version
-        @versions["SDK"]    = self._osal_version
-        @versions["EMV"]    = PAX::EMV.version
-        @versions["Pinpad"] = self._pinpad_version
-      end
-      @versions
-    end
-
     class << self
-      alias_method :restart, :reboot
+      alias restart reboot
     end
   end
 end
-

--- a/mrblib/system.rb
+++ b/mrblib/system.rb
@@ -74,11 +74,7 @@ class PAX
 
     # Returns current battery capacity (%) in the range [-1~100].
     def self.battery
-      if !power_supply
-        75 # TODO: replace by '_battery.to_i'
-      else
-        50
-      end
+      _battery.to_i
     end
 
     # Checks if device is connected to any power supply.

--- a/mrblib/system.rb
+++ b/mrblib/system.rb
@@ -32,7 +32,7 @@ class PAX
 
     # Returns the device serial number.
     def self.serial
-      _serial
+      self._serial
     end
 
     # Defines screen brightness level [0~100].
@@ -41,17 +41,15 @@ class PAX
       level < 0 && level = 0
       level = ((level * 7) / 100).to_i
 
-      # ContextLog.info "Screen Backlight [#{level}]"
-
       if level == 0
-        _kb_backlight = 0
-        _sleep_mode = 1
+        self._kb_backlight = 0
+        self._sleep_mode = 1
       else
-        _kb_backlight = 1
-        _sleep_mode = 0
+        self._kb_backlight = 1
+        self._sleep_mode = 0
       end
 
-      _backlight = level
+      self._backlight = level
     end
 
     # (deprecated) Returns default backlight for DaFunk:
@@ -66,12 +64,12 @@ class PAX
     # Defines system execution mode: 0 (active), 1 (screensaver) and 2
     # (sleep).
     def self.sleep_mode=(mode)
-      _sleep_mode = mode
+      self._sleep_mode = mode
     end
 
     # Defines keyboard backlight behavior: 0 to disable, non-zero to enable.
     def self.kb_backlight=(level)
-      _kb_backlight = level
+      self._kb_backlight = level
     end
 
     # Returns current battery capacity (%) in the range [-1~100].
@@ -85,17 +83,17 @@ class PAX
 
     # Checks if device is connected to any power supply.
     def self.power_supply
-      [POWER_ADAPTER, POWER_USB].include?(_power_supply)
+      [POWER_ADAPTER, POWER_USB].include?(self._power_supply)
     end
 
     # Returns the device model (downcased).
     def self.model
-      _model.to_s.downcase
+      self._model.to_s.downcase
     end
 
     # Reboots the device.
     def self.reboot
-      _reboot
+      self._reboot
     end
 
     # Returns device brand (downcased).
@@ -105,7 +103,7 @@ class PAX
 
     # Updates the main application.
     def self.update(path)
-      ret = install('MAINAPP', path, FILE_TYPE_APP)
+      ret = self.install('MAINAPP', path, FILE_TYPE_APP)
       if !ret
         true
       else
@@ -120,9 +118,9 @@ class PAX
         @versions = {}
 
         @versions['EMV'] = PAX::EMV.version
-        @versions['OS'] = _os_version
-        @versions['Pinpad'] = _pinpad_version
-        @versions['SDK'] = _osal_version
+        @versions['OS'] = self._os_version
+        @versions['Pinpad'] = self._pinpad_version
+        @versions['SDK'] = self._osal_version
       end
       @versions
     end

--- a/mrblib/system.rb
+++ b/mrblib/system.rb
@@ -72,6 +72,11 @@ class PAX
       self._kb_backlight = level
     end
 
+    # Defines the battery capacity type of return (percentage or scale).
+    def self.battery_capacity_type
+      'percentage' # otherwise, 'scale'
+    end
+
     # Returns current battery capacity (%) in the range [-1~100].
     def self.battery
       _battery.to_i

--- a/mrblib/system.rb
+++ b/mrblib/system.rb
@@ -131,7 +131,7 @@ class PAX
     end
 
     class << self
-      alias restart reboot
+      alias_method :restart, :reboot
     end
   end
 end

--- a/src/system.c
+++ b/src/system.c
@@ -20,8 +20,9 @@
 #include "mruby/string.h"
 #include "mruby/value.h"
 
-#include "osal.h"
 #include "runtime_system.h"
+
+#include "osal.h"
 #include "ui.h"
 #include "xui.h"
 
@@ -55,17 +56,17 @@ static struct timeval _battery_timestamp[2];
 static mrb_value
 mrb_s__serial(mrb_state *mrb, mrb_value self)
 {
-    char serial[255 + 1];
-    mrb_int len;
+  char serial[255 + 1];
+  mrb_int len;
 
-    memset(&serial, 0, sizeof(serial));
+  memset(&serial, 0, sizeof(serial));
 
-    len = OsRegGetValue("ro.fac.sn", serial);
+  len = OsRegGetValue("ro.fac.sn", serial);
 
-    if (len > 0)
-        return mrb_str_new(mrb, serial, len);
-    else
-        return mrb_str_new(mrb, 0, 0);
+  if (len > 0)
+    return mrb_str_new(mrb, serial, len);
+  else
+    return mrb_str_new(mrb, 0, 0);
 }
 
 /**
@@ -75,13 +76,13 @@ mrb_s__serial(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_s__set_backlight(mrb_state *mrb, mrb_value self)
 {
-    mrb_int mode;
+  mrb_int mode;
 
-    mrb_get_args(mrb, "i", &mode);
+  mrb_get_args(mrb, "i", &mode);
 
-    OsScrBrightness(mode);
+  OsScrBrightness(mode);
 
-    return mrb_fixnum_value(mode);
+  return mrb_fixnum_value(mode);
 }
 
 /**
@@ -91,13 +92,13 @@ mrb_s__set_backlight(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_s__set_sleep_mode(mrb_state *mrb, mrb_value self)
 {
-    mrb_int mode;
+  mrb_int mode;
 
-    mrb_get_args(mrb, "i", &mode);
+  mrb_get_args(mrb, "i", &mode);
 
-    OsSysSleepEx(mode);
+  OsSysSleepEx(mode);
 
-    return mrb_fixnum_value(mode);
+  return mrb_fixnum_value(mode);
 }
 
 /**
@@ -107,13 +108,13 @@ mrb_s__set_sleep_mode(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_s__set_kb_backlight(mrb_state *mrb, mrb_value self)
 {
-    mrb_int mode;
+  mrb_int mode;
 
-    mrb_get_args(mrb, "i", &mode);
+  mrb_get_args(mrb, "i", &mode);
 
-    OsKbBacklight(mode);
+  OsKbBacklight(mode);
 
-    return mrb_fixnum_value(mode);
+  return mrb_fixnum_value(mode);
 }
 
 /**
@@ -123,31 +124,31 @@ mrb_s__set_kb_backlight(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_s_battery(mrb_state *mrb, mrb_value self)
 {
-    static char capacity_value[255 + 1] = { "-1" };
+  static char capacity_value[255 + 1] = {"-1"};
 
-    FILE *fd;
+  FILE *fd;
 
-    pthread_mutex_lock(&system_lock);
+  pthread_mutex_lock(&system_lock);
 
-    gettimeofday(&_battery_timestamp[1], NULL);
+  gettimeofday(&_battery_timestamp[1], NULL);
 
-    if (_battery_timestamp[1].tv_sec > _battery_timestamp[0].tv_usec)
-    {
-        fd = fopen(BATTERY_CAPACITY_FILE, "r");
+  if (_battery_timestamp[1].tv_sec > _battery_timestamp[0].tv_usec)
+  {
+    fd = fopen(BATTERY_CAPACITY_FILE, "r");
 
-        fgets(capacity_value, sizeof(capacity_value), fd);
+    fgets(capacity_value, sizeof(capacity_value), fd);
 
-        fclose(fd);
-    }
+    fclose(fd);
+  }
 
-    gettimeofday(&_battery_timestamp[0], NULL);
+  gettimeofday(&_battery_timestamp[0], NULL);
 
-    _battery_timestamp[0].tv_sec  += 4;
-    _battery_timestamp[0].tv_usec += 4000000;
+  _battery_timestamp[0].tv_sec += 4;
+  _battery_timestamp[0].tv_usec += 4000000;
 
-    pthread_mutex_unlock(&system_lock);
+  pthread_mutex_unlock(&system_lock);
 
-    return mrb_str_new_cstr(mrb, capacity_value);
+  return mrb_str_new_cstr(mrb, capacity_value);
 }
 
 /**
@@ -156,7 +157,7 @@ mrb_s_battery(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_s__power_supply(mrb_state *mrb, mrb_value self)
 {
-    return mrb_fixnum_value((int) OsCheckPowerSupply());
+  return mrb_fixnum_value((int) OsCheckPowerSupply());
 }
 
 /**
@@ -165,21 +166,21 @@ mrb_s__power_supply(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_addrinfo_s__ip(mrb_state *mrb, mrb_value self)
 {
-    mrb_value host;
-    mrb_int ret = -1;
-    char dnsAddr[50] = "\0";
+  mrb_value host;
+  mrb_int ret = -1;
+  char dnsAddr[50] = "\0";
 
-    mrb_get_args(mrb, "o", &host);
+  mrb_get_args(mrb, "o", &host);
 
-    if (mrb_string_p(host))
-    {
-        ret = OsNetDns(RSTRING_PTR(host), (char *)&dnsAddr, 30000);
-    }
+  if (mrb_string_p(host))
+  {
+    ret = OsNetDns(RSTRING_PTR(host), (char *) &dnsAddr, 30000);
+  }
 
-    if (ret == RET_OK)
-        return mrb_str_new_cstr(mrb, dnsAddr);
-    else
-        return host;
+  if (ret == RET_OK)
+    return mrb_str_new_cstr(mrb, dnsAddr);
+  else
+    return host;
 }
 
 /**
@@ -188,13 +189,13 @@ mrb_addrinfo_s__ip(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_pax_audio_s_beep(mrb_state *mrb, mrb_value self)
 {
-    mrb_int tone, milliseconds;
+  mrb_int tone, milliseconds;
 
-    mrb_get_args(mrb, "ii", &tone, &milliseconds);
+  mrb_get_args(mrb, "ii", &tone, &milliseconds);
 
-    OsBeep(tone, milliseconds);
+  OsBeep(tone, milliseconds);
 
-    return mrb_nil_value();
+  return mrb_nil_value();
 }
 
 /**
@@ -203,7 +204,7 @@ mrb_pax_audio_s_beep(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_pax_s_reboot(mrb_state *mrb, mrb_value self)
 {
-    return mrb_fixnum_value(OsReboot());
+  return mrb_fixnum_value(OsReboot());
 }
 
 /**
@@ -212,19 +213,19 @@ mrb_pax_s_reboot(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_pax_s_hwclock(mrb_state *mrb, mrb_value self)
 {
-    ST_TIME t;
-    mrb_int year, month, day, hour, minute, second;
+  ST_TIME t;
+  mrb_int year, month, day, hour, minute, second;
 
-    mrb_get_args(mrb, "iiiiii", &year, &month, &day, &hour, &minute, &second);
+  mrb_get_args(mrb, "iiiiii", &year, &month, &day, &hour, &minute, &second);
 
-    t.Year = year;
-    t.Month = month;
-    t.Day = day;
-    t.Hour = hour;
-    t.Minute = minute;
-    t.Second = second;
+  t.Year   = year;
+  t.Month  = month;
+  t.Day    = day;
+  t.Hour   = hour;
+  t.Minute = minute;
+  t.Second = second;
 
-    return mrb_fixnum_value(OsSetTime(&t));
+  return mrb_fixnum_value(OsSetTime(&t));
 }
 
 /**
@@ -233,13 +234,13 @@ mrb_pax_s_hwclock(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_pax_s__os_version(mrb_state *mrb, mrb_value self)
 {
-    char version[31] = "\0";
+  char version[31] = "\0";
 
-    memset(&version, 0, sizeof(version));
+  memset(&version, 0, sizeof(version));
 
-    OsGetSysVer(TYPE_OS_VER, version);
+  OsGetSysVer(TYPE_OS_VER, version);
 
-    return mrb_str_new_cstr(mrb, version);
+  return mrb_str_new_cstr(mrb, version);
 }
 
 /**
@@ -248,13 +249,13 @@ mrb_pax_s__os_version(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_pax_s__osal_version(mrb_state *mrb, mrb_value self)
 {
-    char version[31] = "\0";
+  char version[31] = "\0";
 
-    memset(&version, 0, sizeof(version));
+  memset(&version, 0, sizeof(version));
 
-    OsGetSysVer(TYPE_OSAL_VER, version);
+  OsGetSysVer(TYPE_OSAL_VER, version);
 
-    return mrb_str_new_cstr(mrb, version);
+  return mrb_str_new_cstr(mrb, version);
 }
 
 /**
@@ -263,13 +264,13 @@ mrb_pax_s__osal_version(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_pax_s__pinpad_version(mrb_state *mrb, mrb_value self)
 {
-    char version[31] = "\0";
+  char version[31] = "\0";
 
-    memset(&version, 0, sizeof(version));
+  memset(&version, 0, sizeof(version));
 
-    OsGetSysVer(TYPE_PED_VER, version);
+  OsGetSysVer(TYPE_PED_VER, version);
 
-    return mrb_str_new_cstr(mrb, version);
+  return mrb_str_new_cstr(mrb, version);
 }
 
 /**
@@ -278,16 +279,16 @@ mrb_pax_s__pinpad_version(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_system_s__model(mrb_state *mrb, mrb_value self)
 {
-    mrb_int len;
-    char model[64] = "\0";
+  mrb_int len;
+  char model[64] = "\0";
 
-    memset(&model, 0, sizeof(model));
+  memset(&model, 0, sizeof(model));
 
-    len = OsRegGetValue("ro.fac.mach", model);
-    if (len > 0)
-        return mrb_str_new(mrb, model, len);
-    else
-        return mrb_str_new(mrb, 0, 0);
+  len = OsRegGetValue("ro.fac.mach", model);
+  if (len > 0)
+    return mrb_str_new(mrb, model, len);
+  else
+    return mrb_str_new(mrb, 0, 0);
 }
 
 /**
@@ -296,17 +297,17 @@ mrb_system_s__model(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_system_s_os_set_value(mrb_state *mrb, mrb_value self)
 {
-    mrb_value key, value;
-    mrb_int ret;
+  mrb_value key, value;
+  mrb_int ret;
 
-    mrb_get_args(mrb, "SS", &key, &value);
+  mrb_get_args(mrb, "SS", &key, &value);
 
-    ret = OsRegSetValue((char *) RSTRING_PTR(key), (char *) RSTRING_PTR(value));
+  ret = OsRegSetValue((char *) RSTRING_PTR(key), (char *) RSTRING_PTR(value));
 
-    if (ret == RET_OK)
-        return mrb_true_value();
-    else
-        return mrb_false_value();
+  if (ret == RET_OK)
+    return mrb_true_value();
+  else
+    return mrb_false_value();
 }
 
 /**
@@ -315,19 +316,19 @@ mrb_system_s_os_set_value(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_system_s_os_get_value(mrb_state *mrb, mrb_value self)
 {
-    char value[1024] = "\0";
-    mrb_value key;
-    mrb_int len;
+  char value[1024] = "\0";
+  mrb_value key;
+  mrb_int len;
 
-    memset(&value, 0, sizeof(value));
+  memset(&value, 0, sizeof(value));
 
-    mrb_get_args(mrb, "S", &key);
+  mrb_get_args(mrb, "S", &key);
 
-    len = OsRegGetValue(RSTRING_PTR(key), (char *)&value);
-    if (len > 0)
-        return mrb_str_new(mrb, value, len);
-    else
-        return mrb_str_new(mrb, 0, 0);
+  len = OsRegGetValue(RSTRING_PTR(key), (char *) &value);
+  if (len > 0)
+    return mrb_str_new(mrb, value, len);
+  else
+    return mrb_str_new(mrb, 0, 0);
 }
 
 /**
@@ -336,12 +337,12 @@ mrb_system_s_os_get_value(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_system_s_install(mrb_state *mrb, mrb_value self)
 {
-    mrb_int type;
-    mrb_value path, name;
+  mrb_int type;
+  mrb_value path, name;
 
-    mrb_get_args(mrb, "SSi", &name, &path, &type);
+  mrb_get_args(mrb, "SSi", &name, &path, &type);
 
-    return mrb_fixnum_value(OsInstallFile(RSTRING_PTR(name), RSTRING_PTR(path), type));
+  return mrb_fixnum_value(OsInstallFile(RSTRING_PTR(name), RSTRING_PTR(path), type));
 }
 
 /**
@@ -350,9 +351,9 @@ mrb_system_s_install(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_system_s_reload(mrb_state *mrb, mrb_value self)
 {
-    reload_flag = 1; /* TODO: shouldn't be mutex protected?! */
+  reload_flag = 1; /* TODO: shouldn't be mutex protected?! */
 
-    return mrb_true_value();
+  return mrb_true_value();
 }
 
 /********************/
@@ -364,44 +365,44 @@ mrb_system_s_reload(mrb_state *mrb, mrb_value self)
  */
 void mrb_system_init(mrb_state *mrb)
 {
-    static int mutex_init = 0;
+  static int mutex_init = 0;
 
-    struct RClass *audio;
-    struct RClass *pax;
-    struct RClass *system;
+  struct RClass *audio;
+  struct RClass *pax;
+  struct RClass *system;
 
-    pax = mrb_define_class(mrb, "PAX", mrb->object_class);
+  pax = mrb_define_class(mrb, "PAX", mrb->object_class);
 
-    audio = mrb_define_class_under(mrb, pax, "Audio", mrb->object_class);
+  audio = mrb_define_class_under(mrb, pax, "Audio", mrb->object_class);
 
-    mrb_define_class_method(mrb, audio, "beep", mrb_pax_audio_s_beep, MRB_ARGS_REQ(2));
+  mrb_define_class_method(mrb , audio  , "beep"            , mrb_pax_audio_s_beep      , MRB_ARGS_REQ(2));
 
-    system = mrb_define_class_under(mrb, pax, "System", mrb->object_class);
+  system = mrb_define_class_under(mrb, pax, "System", mrb->object_class);
 
-    mrb_define_class_method(mrb, system, "_backlight=", mrb_s__set_backlight, MRB_ARGS_REQ(1));
-    mrb_define_class_method(mrb, system, "_battery", mrb_s_battery, MRB_ARGS_NONE());
-    mrb_define_class_method(mrb, system, "_ip", mrb_addrinfo_s__ip, MRB_ARGS_OPT(1));
-    mrb_define_class_method(mrb, system, "_kb_backlight=", mrb_s__set_kb_backlight, MRB_ARGS_REQ(1));
-    mrb_define_class_method(mrb, system, "_model", mrb_system_s__model, MRB_ARGS_NONE());
-    mrb_define_class_method(mrb, system, "_os_get_value", mrb_system_s_os_get_value, MRB_ARGS_REQ(1));
-    mrb_define_class_method(mrb, system, "_os_set_value", mrb_system_s_os_set_value, MRB_ARGS_REQ(2));
-    mrb_define_class_method(mrb, system, "_os_version", mrb_pax_s__os_version, MRB_ARGS_NONE());
-    mrb_define_class_method(mrb, system, "_osal_version", mrb_pax_s__osal_version, MRB_ARGS_NONE());
-    mrb_define_class_method(mrb, system, "_pinpad_version", mrb_pax_s__pinpad_version, MRB_ARGS_NONE());
-    mrb_define_class_method(mrb, system, "_power_supply", mrb_s__power_supply, MRB_ARGS_NONE());
-    mrb_define_class_method(mrb, system, "_reboot", mrb_pax_s_reboot, MRB_ARGS_NONE());
-    mrb_define_class_method(mrb, system, "_serial", mrb_s__serial, MRB_ARGS_NONE());
-    mrb_define_class_method(mrb, system, "_sleep_mode=", mrb_s__set_sleep_mode, MRB_ARGS_REQ(1));
-    mrb_define_class_method(mrb, system, "hwclock", mrb_pax_s_hwclock, MRB_ARGS_REQ(6));
-    mrb_define_class_method(mrb, system, "install", mrb_system_s_install, MRB_ARGS_REQ(3));
-    mrb_define_class_method(mrb, system, "reload", mrb_system_s_reload, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "_serial"         , mrb_s__serial             , MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "_backlight="     , mrb_s__set_backlight      , MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb , system , "_kb_backlight="  , mrb_s__set_kb_backlight   , MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb , system , "_sleep_mode="    , mrb_s__set_sleep_mode     , MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb , system , "_battery"        , mrb_s_battery             , MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "_power_supply"   , mrb_s__power_supply       , MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "_ip"             , mrb_addrinfo_s__ip        , MRB_ARGS_OPT(1));
+  mrb_define_class_method(mrb , system , "_reboot"         , mrb_pax_s_reboot          , MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "hwclock"         , mrb_pax_s_hwclock         , MRB_ARGS_REQ(6));
+  mrb_define_class_method(mrb , system , "_os_version"     , mrb_pax_s__os_version     , MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "_osal_version"   , mrb_pax_s__osal_version   , MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "_pinpad_version" , mrb_pax_s__pinpad_version , MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "_model"          , mrb_system_s__model       , MRB_ARGS_NONE());
+  mrb_define_class_method(mrb , system , "_os_set_value"   , mrb_system_s_os_set_value , MRB_ARGS_REQ(2));
+  mrb_define_class_method(mrb , system , "_os_get_value"   , mrb_system_s_os_get_value , MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb , system , "install"         , mrb_system_s_install      , MRB_ARGS_REQ(3));
+  mrb_define_class_method(mrb , system , "reload"          , mrb_system_s_reload       , MRB_ARGS_NONE());
 
-    if (!mutex_init)
-    {
-        pthread_mutex_init(&system_lock, NULL);
+  if (!mutex_init)
+  {
+    pthread_mutex_init(&system_lock, NULL);
 
-        mutex_init = 1;
-    }
+    mutex_init = 1;
+  }
 
-    gettimeofday(&_battery_timestamp[0], NULL);
+  gettimeofday(&_battery_timestamp[0], NULL);
 }

--- a/src/system.c
+++ b/src/system.c
@@ -1,283 +1,399 @@
-#include <stdlib.h>
+/**
+ * @file system.c
+ * @brief mruby-pax system utilities.
+ * @platform Pax Prolin
+ * @date 2015-01-14
+ *
+ * @copyright Copyright (c) 2015 CloudWalk, Inc.
+ *
+ */
+
+#include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+
 #include "mruby.h"
-#include "mruby/compile.h"
-#include "mruby/value.h"
 #include "mruby/array.h"
-#include "mruby/string.h"
+#include "mruby/compile.h"
 #include "mruby/hash.h"
+#include "mruby/string.h"
+#include "mruby/value.h"
 
 #include "osal.h"
-#include "xui.h"
-#include "ui.h"
 #include "runtime_system.h"
+#include "ui.h"
+#include "xui.h"
 
+/********************/
+/* Global variables */
+/********************/
+
+/* Extern */
+
+int reload_flag = 0;
+
+/* Static */
+
+static pthread_mutex_t system_lock;
+
+/*********************/
+/* Private functions */
+/*********************/
+
+/**
+ * @brief Returns the device serial number.
+ */
 static mrb_value
 mrb_s__serial(mrb_state *mrb, mrb_value self)
 {
-  char serial[64];
-  mrb_int len;
+    char serial[255 + 1];
+    mrb_int len;
 
-  memset(&serial, 0, sizeof(serial));
+    memset(&serial, 0, sizeof(serial));
 
-	len = OsRegGetValue("ro.fac.sn", serial);
-  if (len > 0)
-    return mrb_str_new(mrb, serial, len);
-  else
-    return mrb_str_new(mrb, 0, 0);
+    len = OsRegGetValue("ro.fac.sn", serial);
+
+    if (len > 0)
+        return mrb_str_new(mrb, serial, len);
+    else
+        return mrb_str_new(mrb, 0, 0);
 }
 
-/*
- * Brightness level [0~10].
- *    0: turn off the backlight
- *   10: brightest
- * The default value is 8. Other values: no action.
+/**
+ * @brief Defines screen brightness level. Default value is 8. Values outside
+ * the range [0~10] result into no action.
  */
 static mrb_value
 mrb_s__set_backlight(mrb_state *mrb, mrb_value self)
 {
-  mrb_int mode;
+    mrb_int mode;
 
-  mrb_get_args(mrb, "i", &mode);
+    mrb_get_args(mrb, "i", &mode);
 
-  OsScrBrightness(mode);
+    OsScrBrightness(mode);
 
-  return mrb_fixnum_value(mode);
+    return mrb_fixnum_value(mode);
 }
 
-/*
- * Sleep level, value range is [0, 2].
- *   0: System runs normally;
- *   1: Screensaver mode.
- *     CPU worksnormally; LCD, key backlight, touch key and touch screen can be woken up by plastic button.
- *   2: System sleeps.
- *     CPU is in standby mode, other modules are closed and can only be woken up by plastic button.
+/**
+ * @brief Defines system execution mode: 0 (active), 1 (screensaver) and 2
+ * (sleep). At screensaver mode, CPU is kept active.
  */
 static mrb_value
 mrb_s__set_sleep_mode(mrb_state *mrb, mrb_value self)
 {
-  mrb_int mode;
+    mrb_int mode;
 
-  mrb_get_args(mrb, "i", &mode);
+    mrb_get_args(mrb, "i", &mode);
 
-  OsSysSleepEx(mode);
+    OsSysSleepEx(mode);
 
-  return mrb_fixnum_value(mode);
+    return mrb_fixnum_value(mode);
 }
 
-/*
- *        0: Turn off the backlight.
- * Non-zero: Turn on the backlight.
+/**
+ * @brief Defines keyboard backlight behavior: 0 to disable, non-zero to
+ * enable.
  */
 static mrb_value
 mrb_s__set_kb_backlight(mrb_state *mrb, mrb_value self)
 {
-  mrb_int mode;
+    mrb_int mode;
 
-  mrb_get_args(mrb, "i", &mode);
+    mrb_get_args(mrb, "i", &mode);
 
-  OsKbBacklight(mode);
+    OsKbBacklight(mode);
 
-  return mrb_fixnum_value(mode);
+    return mrb_fixnum_value(mode);
 }
 
+/**
+ * @brief Returns current battery capacity (%). In the event of an error, the
+ * last known value in the range [-1~100] is returned.
+ */
 static mrb_value
 mrb_s_battery(mrb_state *mrb, mrb_value self)
 {
-  return mrb_fixnum_value(OsCheckBattery());
+    static int battery_percentage = -1;
+
+    FILE *fd;
+    char capacity_value[255 + 1];
+    mrb_value return_value;
+
+    pthread_mutex_lock(&system_lock);
+
+    memset(&return_value, 0, sizeof(mrb_value));
+
+    fd = fopen("/sys/class/power_supply/battery/capacity", "r");
+
+    if (fd)
+    {
+        if (fgets(capacity_value, sizeof(capacity_value), fd))
+        {
+            battery_percentage = atoi(capacity_value);
+        }
+
+        fclose(fd);
+    }
+
+    return_value = mrb_fixnum_value(battery_percentage);
+
+    pthread_mutex_unlock(&system_lock);
+
+    return return_value;
 }
 
+/**
+ * @brief Checks if device is connected to any power supply.
+ */
 static mrb_value
 mrb_s__power_supply(mrb_state *mrb, mrb_value self)
 {
-  return mrb_fixnum_value((int)OsCheckPowerSupply());
+    return mrb_fixnum_value((int) OsCheckPowerSupply());
 }
 
+/**
+ * @brief Returns a given host IP address (DNS).
+ */
 static mrb_value
 mrb_addrinfo_s__ip(mrb_state *mrb, mrb_value self)
 {
-  mrb_value host;
-  mrb_int ret=-1;
-  char dnsAddr[50]="\0";
+    mrb_value host;
+    mrb_int ret = -1;
+    char dnsAddr[50] = "\0";
 
-  mrb_get_args(mrb, "o", &host);
+    mrb_get_args(mrb, "o", &host);
 
-  if (mrb_string_p(host)) {
-    ret = OsNetDns(RSTRING_PTR(host), (char *)&dnsAddr, 30000);
-  }
+    if (mrb_string_p(host))
+    {
+        ret = OsNetDns(RSTRING_PTR(host), (char *)&dnsAddr, 30000);
+    }
 
-  if (ret == RET_OK)
-    return mrb_str_new_cstr(mrb, dnsAddr);
-  else
-    return host;
+    if (ret == RET_OK)
+        return mrb_str_new_cstr(mrb, dnsAddr);
+    else
+        return host;
 }
 
+/**
+ * @brief Plays a beep according to given tone and milliseconds.
+ */
 static mrb_value
 mrb_pax_audio_s_beep(mrb_state *mrb, mrb_value self)
 {
-  mrb_int tone, milliseconds;
+    mrb_int tone, milliseconds;
 
-  mrb_get_args(mrb, "ii", &tone, &milliseconds);
-  OsBeep(tone, milliseconds);
+    mrb_get_args(mrb, "ii", &tone, &milliseconds);
 
-  return mrb_nil_value();
+    OsBeep(tone, milliseconds);
+
+    return mrb_nil_value();
 }
 
+/**
+ * @brief Reboots the device.
+ */
 static mrb_value
 mrb_pax_s_reboot(mrb_state *mrb, mrb_value self)
 {
-  return mrb_fixnum_value(OsReboot());
+    return mrb_fixnum_value(OsReboot());
 }
 
+/**
+ * @brief Defines the time at the system clock.
+ */
 static mrb_value
 mrb_pax_s_hwclock(mrb_state *mrb, mrb_value self)
 {
-  ST_TIME t;
-  mrb_int year, month, day, hour, minute, second;
+    ST_TIME t;
+    mrb_int year, month, day, hour, minute, second;
 
-  mrb_get_args(mrb, "iiiiii", &year, &month, &day, &hour, &minute, &second);
+    mrb_get_args(mrb, "iiiiii", &year, &month, &day, &hour, &minute, &second);
 
-  t.Year   = year;
-  t.Month  = month;
-  t.Day    = day;
-  t.Hour   = hour;
-  t.Minute = minute;
-  t.Second = second;
+    t.Year = year;
+    t.Month = month;
+    t.Day = day;
+    t.Hour = hour;
+    t.Minute = minute;
+    t.Second = second;
 
-  return mrb_fixnum_value(OsSetTime(&t));
+    return mrb_fixnum_value(OsSetTime(&t));
 }
 
+/**
+ * @brief Returns operational system version.
+ */
 static mrb_value
 mrb_pax_s__os_version(mrb_state *mrb, mrb_value self)
 {
-  char version[31]="\0";
+    char version[31] = "\0";
 
-  memset(&version, 0, sizeof(version));
+    memset(&version, 0, sizeof(version));
 
-  OsGetSysVer(TYPE_OS_VER, version);
+    OsGetSysVer(TYPE_OS_VER, version);
 
-  return mrb_str_new_cstr(mrb, version);
+    return mrb_str_new_cstr(mrb, version);
 }
 
+/**
+ * @brief Returns PAX API library version.
+ */
 static mrb_value
 mrb_pax_s__osal_version(mrb_state *mrb, mrb_value self)
 {
-  char version[31]="\0";
+    char version[31] = "\0";
 
-  memset(&version, 0, sizeof(version));
+    memset(&version, 0, sizeof(version));
 
-  OsGetSysVer(TYPE_OSAL_VER, version);
+    OsGetSysVer(TYPE_OSAL_VER, version);
 
-  return mrb_str_new_cstr(mrb, version);
+    return mrb_str_new_cstr(mrb, version);
 }
 
+/**
+ * @brief Returns built-in PED (PINPAD) version.
+ */
 static mrb_value
 mrb_pax_s__pinpad_version(mrb_state *mrb, mrb_value self)
 {
-  char version[31]="\0";
+    char version[31] = "\0";
 
-  memset(&version, 0, sizeof(version));
+    memset(&version, 0, sizeof(version));
 
-  OsGetSysVer(TYPE_PED_VER, version);
+    OsGetSysVer(TYPE_PED_VER, version);
 
-  return mrb_str_new_cstr(mrb, version);
+    return mrb_str_new_cstr(mrb, version);
 }
 
+/**
+ * @brief Returns the device model.
+ */
 static mrb_value
 mrb_system_s__model(mrb_state *mrb, mrb_value self)
 {
-  mrb_int len;
-  char model[64]="\0";
+    mrb_int len;
+    char model[64] = "\0";
 
-  memset(&model, 0, sizeof(model));
+    memset(&model, 0, sizeof(model));
 
-	len = OsRegGetValue("ro.fac.mach", model);
-  if (len > 0)
-    return mrb_str_new(mrb, model, len);
-  else
-    return mrb_str_new(mrb, 0, 0);
+    len = OsRegGetValue("ro.fac.mach", model);
+    if (len > 0)
+        return mrb_str_new(mrb, model, len);
+    else
+        return mrb_str_new(mrb, 0, 0);
 }
 
+/**
+ * @brief Defines a given property value.
+ */
 static mrb_value
 mrb_system_s_os_set_value(mrb_state *mrb, mrb_value self)
 {
-  mrb_value key, value;
-  mrb_int ret;
+    mrb_value key, value;
+    mrb_int ret;
 
-  mrb_get_args(mrb, "SS", &key, &value);
+    mrb_get_args(mrb, "SS", &key, &value);
 
-  ret = OsRegSetValue((char *)RSTRING_PTR(key), (char *)RSTRING_PTR(value));
+    ret = OsRegSetValue((char *) RSTRING_PTR(key), (char *) RSTRING_PTR(value));
 
-  if (ret == RET_OK)
-    return mrb_true_value();
-  else
-    return mrb_false_value();
+    if (ret == RET_OK)
+        return mrb_true_value();
+    else
+        return mrb_false_value();
 }
 
+/**
+ * @brief Returns a given property value.
+ */
 static mrb_value
 mrb_system_s_os_get_value(mrb_state *mrb, mrb_value self)
 {
-  char value[1024]="\0";
-  mrb_value key;
-  mrb_int len;
+    char value[1024] = "\0";
+    mrb_value key;
+    mrb_int len;
 
-  memset(&value, 0, sizeof(value));
+    memset(&value, 0, sizeof(value));
 
-  mrb_get_args(mrb, "S", &key);
+    mrb_get_args(mrb, "S", &key);
 
-  len = OsRegGetValue(RSTRING_PTR(key), (char *)&value);
-  if (len > 0)
-    return mrb_str_new(mrb, value, len);
-  else
-    return mrb_str_new(mrb, 0, 0);
+    len = OsRegGetValue(RSTRING_PTR(key), (char *)&value);
+    if (len > 0)
+        return mrb_str_new(mrb, value, len);
+    else
+        return mrb_str_new(mrb, 0, 0);
 }
 
+/**
+ * @brief Installs a component on the device.
+ */
 static mrb_value
 mrb_system_s_install(mrb_state *mrb, mrb_value self)
 {
-  mrb_int type;
-  mrb_value path, name;
+    mrb_int type;
+    mrb_value path, name;
 
-  mrb_get_args(mrb, "SSi", &name, &path, &type);
+    mrb_get_args(mrb, "SSi", &name, &path, &type);
 
-  return mrb_fixnum_value(OsInstallFile(RSTRING_PTR(name), RSTRING_PTR(path), type));
+    return mrb_fixnum_value(OsInstallFile(RSTRING_PTR(name), RSTRING_PTR(path), type));
 }
 
-reload_flag = 0;
-
+/**
+ * @brief Signals a mruby reload.
+ */
 static mrb_value
 mrb_system_s_reload(mrb_state *mrb, mrb_value self)
 {
-  reload_flag = 1;
-  return mrb_true_value();
+    reload_flag = 1; /* TODO: shouldn't be mutex protected?! */
+
+    return mrb_true_value();
 }
 
-void
-mrb_system_init(mrb_state* mrb)
+/********************/
+/* Public functions */
+/********************/
+
+/**
+ * @brief Exposes mruby-pax system utilities.
+ */
+void mrb_system_init(mrb_state *mrb)
 {
-  struct RClass *pax, *system, *audio;
+    static int mutex_init = 0;
 
-  pax    = mrb_define_class(mrb, "PAX", mrb->object_class);
-  system = mrb_define_class_under(mrb, pax, "System", mrb->object_class);
-  audio  = mrb_define_class_under(mrb, pax, "Audio", mrb->object_class);
+    struct RClass *audio;
+    struct RClass *pax;
+    struct RClass *system;
 
-  mrb_define_class_method(mrb , audio  , "beep"            , mrb_pax_audio_s_beep      , MRB_ARGS_REQ(2));
-  mrb_define_class_method(mrb , system , "_serial"         , mrb_s__serial             , MRB_ARGS_NONE());
-  mrb_define_class_method(mrb , system , "_backlight="     , mrb_s__set_backlight      , MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb , system , "_kb_backlight="  , mrb_s__set_kb_backlight   , MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb , system , "_sleep_mode="    , mrb_s__set_sleep_mode     , MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb , system , "_battery"        , mrb_s_battery             , MRB_ARGS_NONE());
-  mrb_define_class_method(mrb , system , "_power_supply"   , mrb_s__power_supply       , MRB_ARGS_NONE());
-  mrb_define_class_method(mrb , system , "_ip"             , mrb_addrinfo_s__ip        , MRB_ARGS_OPT(1));
-  mrb_define_class_method(mrb , system , "_reboot"         , mrb_pax_s_reboot          , MRB_ARGS_NONE());
-  mrb_define_class_method(mrb , system , "hwclock"         , mrb_pax_s_hwclock         , MRB_ARGS_REQ(6));
-  mrb_define_class_method(mrb , system , "_os_version"     , mrb_pax_s__os_version     , MRB_ARGS_NONE());
-  mrb_define_class_method(mrb , system , "_osal_version"   , mrb_pax_s__osal_version   , MRB_ARGS_NONE());
-  mrb_define_class_method(mrb , system , "_pinpad_version" , mrb_pax_s__pinpad_version , MRB_ARGS_NONE());
-  mrb_define_class_method(mrb , system , "_model"          , mrb_system_s__model       , MRB_ARGS_NONE());
-  mrb_define_class_method(mrb , system , "_os_set_value"   , mrb_system_s_os_set_value , MRB_ARGS_REQ(2));
-  mrb_define_class_method(mrb , system , "_os_get_value"   , mrb_system_s_os_get_value , MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb , system , "install"         , mrb_system_s_install      , MRB_ARGS_REQ(3));
-  mrb_define_class_method(mrb , system , "reload"          , mrb_system_s_reload       , MRB_ARGS_NONE());
+    pax = mrb_define_class(mrb, "PAX", mrb->object_class);
+
+    audio = mrb_define_class_under(mrb, pax, "Audio", mrb->object_class);
+
+    mrb_define_class_method(mrb, audio, "beep", mrb_pax_audio_s_beep, MRB_ARGS_REQ(2));
+
+    system = mrb_define_class_under(mrb, pax, "System", mrb->object_class);
+
+    mrb_define_class_method(mrb, system, "_backlight=", mrb_s__set_backlight, MRB_ARGS_REQ(1));
+    mrb_define_class_method(mrb, system, "_battery", mrb_s_battery, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, system, "_ip", mrb_addrinfo_s__ip, MRB_ARGS_OPT(1));
+    mrb_define_class_method(mrb, system, "_kb_backlight=", mrb_s__set_kb_backlight, MRB_ARGS_REQ(1));
+    mrb_define_class_method(mrb, system, "_model", mrb_system_s__model, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, system, "_os_get_value", mrb_system_s_os_get_value, MRB_ARGS_REQ(1));
+    mrb_define_class_method(mrb, system, "_os_set_value", mrb_system_s_os_set_value, MRB_ARGS_REQ(2));
+    mrb_define_class_method(mrb, system, "_os_version", mrb_pax_s__os_version, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, system, "_osal_version", mrb_pax_s__osal_version, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, system, "_pinpad_version", mrb_pax_s__pinpad_version, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, system, "_power_supply", mrb_s__power_supply, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, system, "_reboot", mrb_pax_s_reboot, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, system, "_serial", mrb_s__serial, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, system, "_sleep_mode=", mrb_s__set_sleep_mode, MRB_ARGS_REQ(1));
+    mrb_define_class_method(mrb, system, "hwclock", mrb_pax_s_hwclock, MRB_ARGS_REQ(6));
+    mrb_define_class_method(mrb, system, "install", mrb_system_s_install, MRB_ARGS_REQ(3));
+    mrb_define_class_method(mrb, system, "reload", mrb_system_s_reload, MRB_ARGS_NONE());
+
+    if (!mutex_init)
+    {
+        pthread_mutex_init(&system_lock, NULL);
+
+        mutex_init = 1;
+    }
 }
-


### PR DESCRIPTION
This PR holds the core updates related to [CCT-257](https://cloudwalk.atlassian.net/browse/CCT-257) and an additional full review of system utilities at the mrbgem mruby-pax:

- **This PR is related to another 2 PRs: [PR #48](https://github.com/cloudwalk/main/pull/48) from `main` and [PR #64](https://github.com/cloudwalk/da_funk/pull/64) from `da_funk`)**
- C code changes are working fine and have a _small-but-**important**_ **protection** against stressing both file system and battery itself.
   - Said protection (see above) could not be coded in Ruby because _mruby 1.x_ seems to not support class variables `@@` and mutexes (at least, not natively)

C code changes mainly contemplates:
- Code formatting
   - Tab: 4 spaces _(only C code, for Ruby: 2 spaces)_
- Code documentation
   - Doxygen's `@brief` tag as function headers
- Battery capacity API review
   - `mrb_s_battery()` new implementation (protected against thread concurrency)
   - `mrb_system_init()` update, to be compliant with the new implementation of `mrb_s_battery()` (see above)

Ruby code changes mainly contemplates:
- Code documentation
   - _loosely based on YARD and RuboCop_
- APIs implementation review 
   - `backlight` method review for dynamic capabilities (previously static)
   - `battery_capacity_type` method creation